### PR TITLE
Update to more specific status codes

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -262,12 +262,12 @@ describe("POST: /[Nonexistent Endpoint]", () => {
   });
 });
 describe("POST: /api/articles/:article_id/comments", () => {
-  describe("200: Success", () => {
+  describe("201: Created", () => {
     test("should take an object with a body and an author and return the posted comment, which has all the relevant keys added to it", () => {
       return request(app)
         .post("/api/articles/1/comments")
         .send({ body: "This is a comment", author: "butter_bridge" })
-        .expect(200)
+        .expect(201)
         .then(({ body: { comment } }) => {
           expect(Object.keys(comment).length).toBe(6);
           // prettier-ignore

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -250,13 +250,13 @@ describe("GET: /api/articles/:article_id/comments", () => {
 
 // POST endpoint tests begin
 describe("POST: /[Nonexistent Endpoint]", () => {
-  describe("401: Unauthorised", () => {
-    test("Invalid endpoint should respond with unauthorised", () => {
+  describe("405: Method Not Allowed", () => {
+    test("Invalid endpoint should respond with not allowed", () => {
       return request(app)
         .post("/api/doesntexist")
-        .expect(401)
+        .expect(405)
         .then(({ body: { error } }) => {
-          expect(error).toBe("Unauthorised");
+          expect(error).toBe("Method Not Allowed");
         });
     });
   });
@@ -333,13 +333,13 @@ describe("POST: /api/articles/:article_id/comments", () => {
 
 // PATCH endpoint tests begin
 describe("PATCH: /[Nonexistent Endpoint]", () => {
-  describe("401: Unauthorised", () => {
-    test("Invalid endpoint should respond with unauthorised", () => {
+  describe("405: Unauthorised", () => {
+    test("Invalid endpoint should respond with not allowed", () => {
       return request(app)
         .patch("/api/doesntexist")
-        .expect(401)
+        .expect(405)
         .then(({ body: { error } }) => {
-          expect(error).toBe("Unauthorised");
+          expect(error).toBe("Method Not Allowed");
         });
     });
   });

--- a/app.js
+++ b/app.js
@@ -39,11 +39,11 @@ app.get("*", (request, response, next) => {
 });
 
 app.post("*", (request, response, next) => {
-  response.status(401).send({ error: "Unauthorised" });
+  response.status(405).send({ error: "Method Not Allowed" });
 });
 
 app.patch("*", (request, response, next) => {
-  response.status(401).send({ error: "Unauthorised" });
+  response.status(405).send({ error: "Method Not Allowed" });
 });
 
 // Error Handling

--- a/src/__controllers__/comments.js
+++ b/src/__controllers__/comments.js
@@ -27,6 +27,6 @@ exports.postComment = (request, response, next) => {
       const { article_id } = request.params;
       return insertComment(body, article_id, author);
     })
-    .then((comment) => response.status(200).send({ comment }))
+    .then((comment) => response.status(201).send({ comment }))
     .catch((error) => next(error));
 };


### PR DESCRIPTION
- POST now uses 201 instead of 200
- invalid POST and PATCH endpoints now respond with 405: Method Not Allowed instead of 401: Unauthorised